### PR TITLE
feat(frontend): add logout button to header

### DIFF
--- a/frontend/src/components/common/AppHeader.vue
+++ b/frontend/src/components/common/AppHeader.vue
@@ -3,6 +3,14 @@
     <v-app-bar-nav-icon @click="emit('toggle-nav')" />
     <v-toolbar-title class="text-h6">{{ title }}</v-toolbar-title>
     <div class="flex-grow-1" />
+    <v-btn
+      v-if="auth.token"
+      icon
+      :title="t('common.logout')"
+      @click="onLogout"
+    >
+      <v-icon icon="mdi-logout" />
+    </v-btn>
   </v-app-bar>
 </template>
 
@@ -10,14 +18,23 @@
   import { computed } from 'vue'
   import { useI18n } from 'vue-i18n'
   import { useRoute } from 'vue-router'
+  import router from '@/router'
+  import { useAuthStore } from '@/stores/auth/useAuthStore'
+  import { RouteName } from '@/types/routes'
 
   const emit = defineEmits<{ (e: 'toggle-nav'): void }>()
 
   const route = useRoute()
   const { t } = useI18n()
+  const auth = useAuthStore()
 
   const title = computed(() => {
     const key = route.meta.titleKey as string | undefined
     return key ? t(key) : 'OSSカタログ管理'
   })
+
+  async function onLogout () {
+    await auth.logout()
+    router.push({ name: RouteName.Login })
+  }
 </script>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "logout": "Logout"
+  },
   "login": {
     "title": "Login",
     "username": "Username",

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -3,7 +3,8 @@
     "search": "検索",
     "save": "保存",
     "cancel": "取消",
-    "delete": "削除"
+    "delete": "削除",
+    "logout": "ログアウト"
   },
   "toast": {
     "saved": "保存しました",

--- a/frontend/src/stores/auth/useAuthStore.ts
+++ b/frontend/src/stores/auth/useAuthStore.ts
@@ -23,7 +23,12 @@ export const useAuthStore = defineStore('auth', {
       OpenAPI.TOKEN = res.accessToken
       localStorage.setItem('jwtToken', res.accessToken)
     },
-    logout () {
+    async logout () {
+      try {
+        await AuthService.logout()
+      } catch {
+        // ignore logout errors
+      }
       this.token = ''
       OpenAPI.TOKEN = undefined
       localStorage.removeItem('jwtToken')


### PR DESCRIPTION
## Summary
- add logout button to top app bar
- call backend logout API and clear credentials
- add i18n strings for logout

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-vuetify')*
- `npm run type-check` *(fails: vue-tsc: not found)*
- `go vet ./...` *(fails: github.com/getkin/kin-openapi: Forbidden)*
- `go test ./...` *(fails: github.com/getkin/kin-openapi: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896019e0b788320aa9f701b6927c515