### PR TITLE
fix login error handling on failed login

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -6,7 +6,8 @@
     "title": "Login",
     "username": "Username",
     "password": "Password",
-    "submit": "Login"
+    "submit": "Login",
+    "failed": "Login failed"
   },
   "project": {
     "table": {

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -129,6 +129,7 @@
     "title": "ログイン",
     "username": "ユーザー名",
     "password": "パスワード",
-    "submit": "ログイン"
+    "submit": "ログイン",
+    "failed": "ログインに失敗しました"
   }
 }

--- a/frontend/src/pages/LoginPage.vue
+++ b/frontend/src/pages/LoginPage.vue
@@ -36,6 +36,7 @@
   import { useRouter } from 'vue-router'
   import { useAuthStore } from '@/stores/auth/useAuthStore'
   import { RouteName } from '@/types/routes'
+  import { useToast } from '@/composables/useToast'
 
   const username = ref('')
   const password = ref('')
@@ -43,12 +44,15 @@
   const router = useRouter()
   const { t } = useI18n()
   const auth = useAuthStore()
+  const toast = useToast()
 
   async function onSubmit () {
     loading.value = true
     try {
       await auth.login(username.value, password.value)
       router.push({ name: RouteName.OssList as any })
+    } catch {
+      toast.error(t('login.failed'))
     } finally {
       loading.value = false
     }

--- a/frontend/src/plugins/http.ts
+++ b/frontend/src/plugins/http.ts
@@ -32,10 +32,13 @@ axios.interceptors.response.use(
       apiError.problem = problem
     }
     if (apiError.status === 401) {
-      const auth = useAuthStore()
-      auth.logout()
-      if (router.currentRoute.value.path !== '/') {
-        router.push('/')
+      const url = error.config?.url || ''
+      if (!url.endsWith('/auth/login') && !url.endsWith('/auth/logout')) {
+        const auth = useAuthStore()
+        auth.logout()
+        if (router.currentRoute.value.path !== '/') {
+          router.push('/')
+        }
       }
     }
     return Promise.reject(apiError)


### PR DESCRIPTION
## Summary
- avoid triggering logout on failed login responses
- show translated error toast when login fails
- add English/Japanese strings for login error

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-config-vuetify')*
- `npm run type-check` *(fails: vue-tsc: not found)*
- `go vet ./...` *(fails: forbidden downloading modules)*
- `go test ./...` *(fails: forbidden downloading modules)*

------
https://chatgpt.com/codex/tasks/task_e_68966dc5983c832080e567c0fc76bb66