### PR TITLE
feat(frontend): validate URL inputs

### DIFF
--- a/frontend/src/components/oss/OssEditDialog.vue
+++ b/frontend/src/components/oss/OssEditDialog.vue
@@ -8,8 +8,16 @@
       <v-card-text>
         <v-form ref="formRef">
           <v-text-field v-model="form.name" label="Name" required />
-          <v-text-field v-model="form.homepageUrl" label="Homepage URL" />
-          <v-text-field v-model="form.repositoryUrl" label="Repository URL" />
+          <v-text-field
+            v-model="form.homepageUrl"
+            label="Homepage URL"
+            :rules="[urlRule]"
+          />
+          <v-text-field
+            v-model="form.repositoryUrl"
+            label="Repository URL"
+            :rules="[urlRule]"
+          />
           <v-select
             v-model="form.primaryLanguage"
             clearable
@@ -64,6 +72,16 @@
   }>()
 
   const { t } = useI18n()
+
+  const urlRule = (v?: string) => {
+    if (!v) return true
+    try {
+      new URL(v)
+      return true
+    } catch {
+      return t('error.invalidUrl')
+    }
+  }
 
   const languageOptions = ['C/C++', 'Java', 'Python', 'Go', 'Rust', 'PHP', 'C#']
   const layerOptions: Layer[] = [
@@ -174,6 +192,8 @@
   }
 
   async function onSave () {
+    const result = await formRef.value?.validate()
+    if (!result?.valid) return
     saving.value = true
     try {
       if (props.ossId) {

--- a/frontend/src/components/oss/OssVersionEditDialog.vue
+++ b/frontend/src/components/oss/OssVersionEditDialog.vue
@@ -6,10 +6,10 @@
       </v-card-title>
       <v-card-text>
         <v-form ref="formRef">
-          <v-text-field v-model="form.version" label="Version" :disabled="!isNew" required />
+          <v-text-field v-model="form.version" :disabled="!isNew" label="Version" required />
           <v-text-field v-model="form.releaseDate" label="Release Date" type="date" />
           <v-text-field v-model="form.licenseExpressionRaw" label="License Expression" />
-          <v-text-field v-model="form.purl" label="PURL" />
+          <v-text-field v-model="form.purl" label="PURL" :rules="[urlRule]" />
           <v-text-field v-model="form.cpeListInput" label="CPE List" />
           <v-text-field v-model="form.hashSha256" label="SHA256" />
           <v-checkbox v-model="form.modified" label="Modified" />
@@ -20,7 +20,11 @@
             :items="supplierTypeOptions"
             label="Supplier Type"
           />
-          <v-text-field v-model="form.forkOriginUrl" label="Fork Origin URL" />
+          <v-text-field
+            v-model="form.forkOriginUrl"
+            label="Fork Origin URL"
+            :rules="[urlRule]"
+          />
         </v-form>
       </v-card-text>
       <v-card-actions>
@@ -55,6 +59,16 @@
   const emit = defineEmits<{ (e: 'update:open', v: boolean): void, (e: 'saved'): void }>()
 
   const { t } = useI18n()
+
+  const urlRule = (v?: string) => {
+    if (!v) return true
+    try {
+      new URL(v)
+      return true
+    } catch {
+      return t('error.invalidUrl')
+    }
+  }
 
   const modelOpen = computed({
     get: () => props.open,
@@ -159,6 +173,8 @@
 
   async function onSave () {
     if (!props.ossId) return
+    const result = await formRef.value?.validate()
+    if (!result?.valid) return
     saving.value = true
     try {
       const cpeList = form.cpeListInput

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -39,5 +39,8 @@
       "save": "Save",
       "cancel": "Cancel"
     }
+  },
+  "error": {
+    "invalidUrl": "Invalid URL"
   }
 }

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -15,7 +15,8 @@
     "fetchFailed": "取得に失敗しました",
     "saveFailed": "保存に失敗しました",
     "deleteFailed": "削除に失敗しました",
-    "exportFailed": "エクスポートに失敗しました"
+    "exportFailed": "エクスポートに失敗しました",
+    "invalidUrl": "URLが不正です"
   },
   "oss": {
     "listTitle": "OSSコンポーネント一覧",


### PR DESCRIPTION
## Summary
- add Vuetify URL validation rules for OSS component and version dialogs
- prevent submitting invalid URLs by validating form before save
- localize URL validation error messages

## Testing
- `go vet ./...`
- `go test ./...`
- `cd frontend && npm ci && npm run lint`

Fixes #4

------
https://chatgpt.com/codex/tasks/task_e_68967c3c83e08320805f12a97aa4e6d0