### PR TITLE
fix(frontend): adjust OSS table column widths

### DIFF
--- a/frontend/src/components/oss/OssTable.vue
+++ b/frontend/src/components/oss/OssTable.vue
@@ -20,10 +20,10 @@
           <th class="text-left">{{ $t('oss.table.name') }}</th>
           <th class="text-left">{{ $t('oss.table.homepage') }}</th>
           <th class="text-left">{{ $t('oss.table.repository') }}</th>
-          <th class="text-left">{{ $t('oss.table.primaryLanguage') }}</th>
-          <th class="text-left">{{ $t('oss.table.layers') }}</th>
+          <th class="text-left" style="width: 10ch">{{ $t('oss.table.primaryLanguage') }}</th>
+          <th class="text-left" style="width: 12ch">{{ $t('oss.table.layers') }}</th>
           <th class="text-left">{{ $t('oss.table.tags') }}</th>
-          <th class="text-left">{{ $t('oss.table.actions') }}</th>
+          <th class="text-left" style="width: 120px">{{ $t('oss.table.actions') }}</th>
         </tr>
       </template>
       <template #item="{ item }">
@@ -45,8 +45,8 @@
               target="_blank"
             >{{ item.repositoryUrl }}</a>
           </td>
-          <td>{{ item.primaryLanguage }}</td>
-          <td>{{ (item.layers || []).join(', ') }}</td>
+          <td style="width: 10ch">{{ item.primaryLanguage }}</td>
+          <td style="width: 12ch">{{ (item.layers || []).join(', ') }}</td>
           <td>
             <v-chip
               v-for="tag in item.tags"
@@ -56,7 +56,7 @@
               variant="tonal"
             >{{ tag.name }}</v-chip>
           </td>
-          <td class="text-right">
+          <td class="text-right" style="width: 120px">
             <v-icon
               class="mr-2"
               size="small"


### PR DESCRIPTION
## Summary
- fix column widths for primary language, layers, and actions in OSS table

## Testing
- `npm run lint`
- `go generate ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68968b811990832094d0309358cec2ff