### PR TITLE
feat: add license list for version creation

### DIFF
--- a/frontend/public/licenses.json
+++ b/frontend/public/licenses.json
@@ -1,0 +1,80 @@
+[
+  {
+    "key": "agpl-3.0",
+    "name": "GNU Affero General Public License v3.0",
+    "spdx_id": "AGPL-3.0",
+    "url": "https://api.github.com/licenses/agpl-3.0"
+  },
+  {
+    "key": "apache-2.0",
+    "name": "Apache License 2.0",
+    "spdx_id": "Apache-2.0",
+    "url": "https://api.github.com/licenses/apache-2.0"
+  },
+  {
+    "key": "bsd-2-clause",
+    "name": "BSD 2-Clause \"Simplified\" License",
+    "spdx_id": "BSD-2-Clause",
+    "url": "https://api.github.com/licenses/bsd-2-clause"
+  },
+  {
+    "key": "bsd-3-clause",
+    "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+    "spdx_id": "BSD-3-Clause",
+    "url": "https://api.github.com/licenses/bsd-3-clause"
+  },
+  {
+    "key": "bsl-1.0",
+    "name": "Boost Software License 1.0",
+    "spdx_id": "BSL-1.0",
+    "url": "https://api.github.com/licenses/bsl-1.0"
+  },
+  {
+    "key": "cc0-1.0",
+    "name": "Creative Commons Zero v1.0 Universal",
+    "spdx_id": "CC0-1.0",
+    "url": "https://api.github.com/licenses/cc0-1.0"
+  },
+  {
+    "key": "epl-2.0",
+    "name": "Eclipse Public License 2.0",
+    "spdx_id": "EPL-2.0",
+    "url": "https://api.github.com/licenses/epl-2.0"
+  },
+  {
+    "key": "gpl-2.0",
+    "name": "GNU General Public License v2.0",
+    "spdx_id": "GPL-2.0",
+    "url": "https://api.github.com/licenses/gpl-2.0"
+  },
+  {
+    "key": "gpl-3.0",
+    "name": "GNU General Public License v3.0",
+    "spdx_id": "GPL-3.0",
+    "url": "https://api.github.com/licenses/gpl-3.0"
+  },
+  {
+    "key": "lgpl-2.1",
+    "name": "GNU Lesser General Public License v2.1",
+    "spdx_id": "LGPL-2.1",
+    "url": "https://api.github.com/licenses/lgpl-2.1"
+  },
+  {
+    "key": "mit",
+    "name": "MIT License",
+    "spdx_id": "MIT",
+    "url": "https://api.github.com/licenses/mit"
+  },
+  {
+    "key": "mpl-2.0",
+    "name": "Mozilla Public License 2.0",
+    "spdx_id": "MPL-2.0",
+    "url": "https://api.github.com/licenses/mpl-2.0"
+  },
+  {
+    "key": "unlicense",
+    "name": "The Unlicense",
+    "spdx_id": "Unlicense",
+    "url": "https://api.github.com/licenses/unlicense"
+  }
+]

--- a/frontend/src/components/common/AppHeader.vue
+++ b/frontend/src/components/common/AppHeader.vue
@@ -35,6 +35,6 @@
 
   async function onLogout () {
     await auth.logout()
-    router.push({ name: RouteName.Login })
+    router.push({ name: RouteName.Login as any })
   }
 </script>

--- a/frontend/src/components/oss/OssVersionEditDialog.vue
+++ b/frontend/src/components/oss/OssVersionEditDialog.vue
@@ -8,7 +8,15 @@
         <v-form ref="formRef">
           <v-text-field v-model="form.version" :disabled="!isNew" label="Version" required />
           <v-text-field v-model="form.releaseDate" label="Release Date" type="date" />
-          <v-text-field v-model="form.licenseExpressionRaw" label="License Expression" />
+          <v-select
+            v-model="form.licenseExpressionRaw"
+            clearable
+            item-props
+            item-title="title"
+            item-value="value"
+            :items="licenseOptions"
+            label="License"
+          />
           <v-text-field v-model="form.purl" label="PURL" :rules="[urlRule]" />
           <v-text-field v-model="form.cpeListInput" label="CPE List" />
           <v-text-field v-model="form.hashSha256" label="SHA256" />
@@ -45,7 +53,7 @@
     OssVersionUpdateRequest,
     SupplierType,
   } from '@/api'
-  import { computed, reactive, ref, watch } from 'vue'
+  import { computed, onMounted, reactive, ref, watch } from 'vue'
   import { useI18n } from 'vue-i18n'
   import { OssVersionsService } from '@/api'
 
@@ -104,6 +112,22 @@
   })
 
   const supplierTypeOptions: SupplierType[] = ['UPSTREAM', 'INTERNAL_FORK', 'REPACKAGE']
+
+  const licenseOptions = ref<{ title: string, value: string, subtitle: string }[]>([])
+
+  onMounted(async () => {
+    try {
+      const res = await fetch('/licenses.json')
+      const data: Array<{ key: string, name: string, spdx_id: string, url: string }> = await res.json()
+      licenseOptions.value = data.map(l => ({
+        title: l.key,
+        value: l.spdx_id,
+        subtitle: l.name,
+      }))
+    } catch (error) {
+      console.error(error)
+    }
+  })
 
   const formRef = ref()
   const saving = ref(false)


### PR DESCRIPTION
## Summary
- load OSS license options from local JSON for offline use
- fix router type error in header logout handler

## Testing
- `npm ci`
- `npm run lint`
- `npm run type-check`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68968bb345ac8320bbed2b49b1913195