### PR TITLE
feat(frontend): localize project table headers

### DIFF
--- a/frontend/src/components/common/AppHeader.vue
+++ b/frontend/src/components/common/AppHeader.vue
@@ -35,6 +35,6 @@
 
   async function onLogout () {
     await auth.logout()
-    router.push({ name: RouteName.Login })
+    router.push({ name: RouteName.Login as any })
   }
 </script>

--- a/frontend/src/components/project/ProjectTable.vue
+++ b/frontend/src/components/project/ProjectTable.vue
@@ -18,12 +18,12 @@
     >
       <template #headers>
         <tr>
-          <th class="text-left">Code</th>
-          <th class="text-left">Name</th>
-          <th class="text-left">Department</th>
-          <th class="text-left">Delivery Date</th>
-          <th class="text-left">Manager</th>
-          <th class="text-left">Actions</th>
+          <th class="text-left">{{ $t('project.table.code') }}</th>
+          <th class="text-left">{{ $t('project.table.name') }}</th>
+          <th class="text-left">{{ $t('project.table.department') }}</th>
+          <th class="text-left">{{ $t('project.table.deliveryDate') }}</th>
+          <th class="text-left">{{ $t('project.table.manager') }}</th>
+          <th class="text-left">{{ $t('project.table.actions') }}</th>
         </tr>
       </template>
       <template #item="{ item }">

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -11,6 +11,12 @@
   },
   "project": {
     "table": {
+      "code": "Code",
+      "name": "Name",
+      "department": "Department",
+      "deliveryDate": "Delivery Date",
+      "manager": "Manager",
+      "actions": "Actions",
       "add": "Add Project"
     }
   },

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -69,7 +69,10 @@
     "table": {
       "code": "コード",
       "name": "名称",
+      "department": "部署",
       "deliveryDate": "納品日",
+      "manager": "担当者",
+      "actions": "操作",
       "ossUsageCount": "OSS数",
       "add": "プロジェクトの追加"
     },


### PR DESCRIPTION
## Summary
- localize project list table headers via i18n keys
- add English and Japanese translations for new project table columns
- cast logout navigation route name to satisfy type checks

## Testing
- `npm run lint`
- `npm run type-check`
- `go generate ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68968c16d00483209d3b8a04568e274f