### PR TITLE
fix: set width for actions column

### DIFF
--- a/frontend/src/components/oss/OssVersionListDialog.vue
+++ b/frontend/src/components/oss/OssVersionListDialog.vue
@@ -17,14 +17,14 @@
             <tr>
               <th class="text-left">{{ t('oss.versionList.version') }}</th>
               <th class="text-left">{{ t('oss.versionList.releaseDate') }}</th>
-              <th class="text-left">{{ t('oss.table.actions') }}</th>
+              <th class="text-left" style="width: 120px">{{ t('oss.table.actions') }}</th>
             </tr>
           </template>
           <template #item="{ item }">
             <tr>
               <td>{{ item.version }}</td>
               <td>{{ item.releaseDate }}</td>
-              <td class="text-right">
+              <td class="text-right" style="width: 120px">
                 <v-btn icon="mdi-pencil" variant="text" @click.stop="openEdit(item.id)" />
                 <v-btn icon="mdi-package-variant-plus" variant="text" @click.stop="openProjectSelect(item.id)" />
                 <v-btn icon="mdi-view-list" variant="text" @click.stop="openUsageList(item.id)" />

--- a/frontend/src/components/project/ProjectTable.vue
+++ b/frontend/src/components/project/ProjectTable.vue
@@ -23,7 +23,7 @@
           <th class="text-left">{{ $t('project.table.department') }}</th>
           <th class="text-left">{{ $t('project.table.deliveryDate') }}</th>
           <th class="text-left">{{ $t('project.table.manager') }}</th>
-          <th class="text-left">{{ $t('project.table.actions') }}</th>
+          <th class="text-left" style="width: 120px">{{ $t('project.table.actions') }}</th>
         </tr>
       </template>
       <template #item="{ item }">
@@ -33,7 +33,7 @@
           <td>{{ item.department }}</td>
           <td>{{ item.deliveryDate }}</td>
           <td>{{ item.manager }}</td>
-          <td class="text-right">
+          <td class="text-right" style="width: 120px">
             <v-btn icon="mdi-pencil" variant="text" @click.stop="emit('detail', item)" />
             <v-btn icon="mdi-view-list" variant="text" @click.stop="emit('usage', item)" />
             <v-menu location="bottom">


### PR DESCRIPTION
## Summary
- ensure a consistent 120px width for the actions column in project and version tables

## Testing
- `npm test` (fails: missing script)
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_689696dd55748320b911f1d4e8fde61f