### PR TITLE
feat: add confirmation dialogs before deleting items

### DIFF
--- a/frontend/src/components/oss/OssVersionListDialog.vue
+++ b/frontend/src/components/oss/OssVersionListDialog.vue
@@ -149,6 +149,7 @@
 
   async function remove (id: string) {
     if (!props.ossId) return
+    if (!confirm(t('common.confirmDelete'))) return
     await OssVersionsService.deleteOssVersion({ ossId: props.ossId, versionId: id })
     await load()
   }

--- a/frontend/src/components/project/ProjectTable.vue
+++ b/frontend/src/components/project/ProjectTable.vue
@@ -47,6 +47,9 @@
                 <v-list-item @click="emitExport(item.id, 'spdx-json')">
                   <v-list-item-title>{{ $t('export.spdx') }}</v-list-item-title>
                 </v-list-item>
+                <v-list-item @click="emit('delete', item)">
+                  <v-list-item-title>{{ $t('common.delete') }}</v-list-item-title>
+                </v-list-item>
               </v-list>
             </v-menu>
           </td>
@@ -70,7 +73,7 @@
   defineProps<Props>()
   const emit = defineEmits<{
     (e: 'update:page' | 'update:items-per-page', value: number): void
-    (e: 'row-click' | 'detail' | 'usage', item: Project): void
+    (e: 'row-click' | 'detail' | 'usage' | 'delete', item: Project): void
     (e: 'export', payload: { id: string, format: 'csv' | 'spdx-json' }): void
     (e: 'create'): void
   }>()

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,6 +1,8 @@
 {
   "common": {
-    "logout": "Logout"
+    "logout": "Logout",
+    "delete": "Delete",
+    "confirmDelete": "Are you sure you want to delete?"
   },
   "login": {
     "title": "Login",
@@ -46,7 +48,11 @@
       "cancel": "Cancel"
     }
   },
+  "toast": {
+    "deleted": "Deleted"
+  },
   "error": {
-    "invalidUrl": "Invalid URL"
+    "invalidUrl": "Invalid URL",
+    "deleteFailed": "Failed to delete"
   }
 }

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -4,7 +4,8 @@
     "save": "保存",
     "cancel": "取消",
     "delete": "削除",
-    "logout": "ログアウト"
+    "logout": "ログアウト",
+    "confirmDelete": "削除してよろしいですか？"
   },
   "toast": {
     "saved": "保存しました",

--- a/frontend/src/pages/OssListPage.vue
+++ b/frontend/src/pages/OssListPage.vue
@@ -1,8 +1,25 @@
 <template>
   <v-container fluid>
-    <OssTable />
+    <OssTable ref="tableRef" @delete="onDelete" />
   </v-container>
 </template>
 
 <script setup lang="ts">
+  import type { OssComponent } from '@/api'
+  import { ref } from 'vue'
+  import { useI18n } from 'vue-i18n'
+  import { OssService } from '@/api'
+
+  const { t } = useI18n()
+  const tableRef = ref<{ reload: () => void }>()
+
+  async function onDelete (item: OssComponent) {
+    if (!confirm(t('common.confirmDelete'))) return
+    try {
+      await OssService.deprecateOssComponent({ ossId: item.id })
+      tableRef.value?.reload()
+    } catch (error) {
+      console.error(error)
+    }
+  }
 </script>

--- a/frontend/src/pages/ProjectListPage.vue
+++ b/frontend/src/pages/ProjectListPage.vue
@@ -13,6 +13,7 @@
       :page="page"
       :total-items="total"
       @create="onCreate"
+      @delete="onDelete"
       @detail="onDetail"
       @export="onExport"
       @row-click="onRowClick"
@@ -34,6 +35,7 @@
 </template>
 
 <script setup lang="ts">
+  import type { Project } from '@/api'
   import { useI18n } from 'vue-i18n'
   import { ExportService } from '@/api'
   import { useProjectStore } from '@/stores/useProjectStore'
@@ -92,6 +94,17 @@
   function showToast (msg: string) {
     snackbarMessage.value = msg
     snackbar.value = true
+  }
+  async function onDelete (item: Project) {
+    if (!confirm(t('common.confirmDelete'))) return
+    try {
+      await store.delete(item.id)
+      await fetchList()
+      showToast(t('toast.deleted'))
+    } catch (error) {
+      console.error(error)
+      showToast(t('error.deleteFailed'))
+    }
   }
   async function onExport (payload: { id: string, format: 'csv' | 'spdx-json' }) {
     exporting.value = true


### PR DESCRIPTION
## Summary
- add confirmation prompts before deleting OSS components, versions, and projects
- localize common deletion confirmation message

## Testing
- `go vet ./...`
- `go test ./...`
- `cd frontend && npm run lint`
- `cd frontend && npm run type-check`

Closes #8

------
https://chatgpt.com/codex/tasks/task_e_689699fbd7f88320bbbc42278d47e553