### PR TITLE
Add license column to OSS version list dialog

### DIFF
--- a/frontend/src/components/oss/OssVersionListDialog.vue
+++ b/frontend/src/components/oss/OssVersionListDialog.vue
@@ -17,6 +17,7 @@
             <tr>
               <th class="text-left">{{ t('oss.versionList.version') }}</th>
               <th class="text-left">{{ t('oss.versionList.releaseDate') }}</th>
+              <th class="text-left">{{ t('oss.versionList.license') }}</th>
               <th class="text-left" style="width: 120px">{{ t('oss.table.actions') }}</th>
             </tr>
           </template>
@@ -24,6 +25,7 @@
             <tr>
               <td>{{ item.version }}</td>
               <td>{{ item.releaseDate }}</td>
+              <td>{{ item.licenseConcluded || item.licenseExpressionRaw }}</td>
               <td class="text-right" style="width: 120px">
                 <v-btn icon="mdi-pencil" variant="text" @click.stop="openEdit(item.id)" />
                 <v-btn icon="mdi-package-variant-plus" variant="text" @click.stop="openProjectSelect(item.id)" />

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -38,6 +38,7 @@
       "title": "Versions",
       "version": "Version",
       "releaseDate": "Release Date",
+      "license": "License",
       "close": "Close",
       "add": "Add Version"
     },

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -50,6 +50,7 @@
       "title": "バージョン一覧",
       "version": "バージョン",
       "releaseDate": "リリース日",
+      "license": "ライセンス",
       "close": "閉じる",
       "add": "バージョン追加"
     },


### PR DESCRIPTION
## Summary
- display license in OSS version list dialog
- add i18n keys

## Testing
- `npm run lint`
- `go generate ./...`
- `go vet ./...`
- `go test ./...`

Closes #15

------
https://chatgpt.com/codex/tasks/task_e_68969c523ba48320995e3257383e7018