### PR TITLE
feat: localize project detail dialog labels

### DIFF
--- a/frontend/src/components/project/ProjectDetailDialog.vue
+++ b/frontend/src/components/project/ProjectDetailDialog.vue
@@ -4,12 +4,34 @@
       <v-card-title>{{ isNew ? $t('project.detail.titleNew') : $t('project.detail.titleEdit') }}</v-card-title>
       <v-card-text>
         <v-form ref="formRef">
-          <v-text-field v-model="form.projectCode" :disabled="!isNew" label="Code" required />
-          <v-text-field v-model="form.name" label="Name" required />
-          <v-text-field v-model="form.department" label="Department" />
-          <v-text-field v-model="form.manager" label="Manager" />
-          <v-text-field v-model="form.deliveryDate" label="Delivery Date" type="date" />
-          <v-textarea v-model="form.description" label="Description" />
+          <v-text-field
+            v-model="form.projectCode"
+            :disabled="!isNew"
+            :label="$t('project.detail.code')"
+            required
+          />
+          <v-text-field
+            v-model="form.name"
+            :label="$t('project.detail.name')"
+            required
+          />
+          <v-text-field
+            v-model="form.department"
+            :label="$t('project.detail.department')"
+          />
+          <v-text-field
+            v-model="form.manager"
+            :label="$t('project.detail.manager')"
+          />
+          <v-text-field
+            v-model="form.deliveryDate"
+            :label="$t('project.detail.deliveryDate')"
+            type="date"
+          />
+          <v-textarea
+            v-model="form.description"
+            :label="$t('project.detail.description')"
+          />
         </v-form>
       </v-card-text>
       <v-card-actions>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -20,6 +20,18 @@
       "manager": "Manager",
       "actions": "Actions",
       "add": "Add Project"
+    },
+    "detail": {
+      "titleNew": "Add Project",
+      "titleEdit": "Edit Project",
+      "code": "Code",
+      "name": "Name",
+      "department": "Department",
+      "manager": "Manager",
+      "deliveryDate": "Delivery Date",
+      "description": "Description",
+      "save": "Save",
+      "cancel": "Cancel"
     }
   },
   "oss": {

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -86,6 +86,12 @@
     "detail": {
       "titleNew": "プロジェクト作成",
       "titleEdit": "プロジェクト編集",
+      "code": "コード",
+      "name": "名称",
+      "department": "部署",
+      "manager": "担当者",
+      "deliveryDate": "納品日",
+      "description": "説明",
       "save": "保存",
       "cancel": "キャンセル"
     },


### PR DESCRIPTION
## Summary
- Localize project detail dialog form labels using i18n
- Add English and Japanese translations for project detail fields

## Testing
- `go vet ./internal/...`
- `go vet ./pkg/...`
- `go test ./...`
- `npm --prefix frontend ci`
- `npm --prefix frontend run lint`

Closes #10

------
https://chatgpt.com/codex/tasks/task_e_68969e42f01c8320854430d4311257a9