### PR TITLE
feat: add user management screen

### DIFF
--- a/frontend/src/components/common/AppNavDrawer.vue
+++ b/frontend/src/components/common/AppNavDrawer.vue
@@ -14,7 +14,9 @@
 
 <script setup lang="ts">
   import type { RouteLocationRaw } from 'vue-router'
+  import { computed } from 'vue'
   import { useI18n } from 'vue-i18n'
+  import { useAuthStore } from '@/stores/auth/useAuthStore'
 
   interface NavItem {
     titleKey: string
@@ -25,12 +27,19 @@
   const emit = defineEmits<{ (e: 'navigate'): void }>()
 
   const { t } = useI18n()
+  const auth = useAuthStore()
 
-  const items: NavItem[] = [
-    { titleKey: 'oss.listTitle', icon: 'mdi-package-variant', to: '/' },
-    { titleKey: 'project.listTitle', icon: 'mdi-briefcase', to: '/projects' },
-    { titleKey: 'settings.title', icon: 'mdi-cog', to: '/settings' },
-  ]
+  const items = computed<NavItem[]>(() => {
+    const list: NavItem[] = [
+      { titleKey: 'oss.listTitle', icon: 'mdi-package-variant', to: '/' },
+      { titleKey: 'project.listTitle', icon: 'mdi-briefcase', to: '/projects' },
+    ]
+    if (auth.roles.includes('ADMIN')) {
+      list.push({ titleKey: 'user.listTitle', icon: 'mdi-account-multiple', to: '/users' })
+    }
+    list.push({ titleKey: 'settings.title', icon: 'mdi-cog', to: '/settings' })
+    return list
+  })
 
   function onNavigate () {
     emit('navigate')

--- a/frontend/src/components/user/UserDetailDialog.vue
+++ b/frontend/src/components/user/UserDetailDialog.vue
@@ -1,0 +1,145 @@
+<template>
+  <v-dialog v-model="modelOpen" max-width="600">
+    <v-card>
+      <v-card-title>{{ isNew ? $t('user.detail.titleNew') : $t('user.detail.titleEdit') }}</v-card-title>
+      <v-card-text>
+        <v-form ref="formRef">
+          <v-text-field
+            v-model="form.username"
+            :disabled="!isNew"
+            :label="$t('user.detail.username')"
+            required
+          />
+          <v-text-field
+            v-model="form.displayName"
+            :label="$t('user.detail.displayName')"
+          />
+          <v-text-field
+            v-model="form.email"
+            :label="$t('user.detail.email')"
+          />
+          <v-text-field
+            v-model="form.password"
+            :label="$t('user.detail.password')"
+            type="password"
+          />
+          <v-select
+            v-model="form.roles"
+            :items="roles"
+            :label="$t('user.detail.roles')"
+            multiple
+          />
+          <v-switch
+            v-model="form.active"
+            :label="$t('user.detail.active')"
+          />
+        </v-form>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="primary" :loading="saving" @click="onSave">{{ $t('user.detail.save') }}</v-btn>
+        <v-btn text @click="close">{{ $t('user.detail.cancel') }}</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+  import type { UserCreateRequest, UserUpdateRequest } from '@/api'
+  import { computed, reactive, ref, watch } from 'vue'
+  import { useUserStore } from '@/stores/useUserStore'
+
+  interface Props {
+    open: boolean
+    userId?: string
+  }
+
+  const props = defineProps<Props>()
+  const emit = defineEmits<{ (e: 'update:open', v: boolean): void, (e: 'saved'): void }>()
+
+  const store = useUserStore()
+
+  const modelOpen = computed({
+    get: () => props.open,
+    set: (v: boolean) => emit('update:open', v),
+  })
+
+  const isNew = computed(() => !props.userId)
+
+  const roles = ['ADMIN', 'EDITOR', 'VIEWER']
+
+  const form = reactive<UserCreateRequest>({
+    username: '',
+    displayName: undefined,
+    email: undefined,
+    password: undefined,
+    roles: [],
+    active: true,
+  })
+
+  const formRef = ref()
+  const saving = ref(false)
+
+  watch(() => props.open, val => {
+    if (val) loadDetail()
+  })
+  watch(() => props.userId, () => {
+    if (props.open) loadDetail()
+  })
+
+  async function loadDetail () {
+    if (!props.userId) {
+      resetForm()
+      return
+    }
+    try {
+      const detail = await store.get(props.userId)
+      form.username = detail.username
+      form.displayName = detail.displayName ?? undefined
+      form.email = detail.email ?? undefined
+      form.password = undefined
+      form.roles = detail.roles.slice()
+      form.active = detail.active
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  function resetForm () {
+    form.username = ''
+    form.displayName = undefined
+    form.email = undefined
+    form.password = undefined
+    form.roles = []
+    form.active = true
+  }
+
+  function close () {
+    emit('update:open', false)
+  }
+
+  async function onSave () {
+    saving.value = true
+    try {
+      if (isNew.value) {
+        const payload: UserCreateRequest = { ...form }
+        await store.create(payload)
+      } else if (props.userId) {
+        const payload: UserUpdateRequest = {
+          displayName: form.displayName,
+          email: form.email,
+          password: form.password,
+          roles: form.roles,
+          active: form.active,
+        }
+        await store.update(props.userId, payload)
+      }
+      emit('saved')
+      close()
+    } catch (error) {
+      console.error(error)
+    } finally {
+      saving.value = false
+    }
+  }
+</script>

--- a/frontend/src/components/user/UserTable.vue
+++ b/frontend/src/components/user/UserTable.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <div class="d-flex justify-end mb-2">
+      <v-btn color="primary" @click="emit('create')">
+        {{ $t('user.table.add') }}
+      </v-btn>
+    </div>
+    <v-data-table
+      item-value="id"
+      :items="items"
+      :items-length="totalItems"
+      :items-per-page="itemsPerPage"
+      :loading="loading"
+      :page="page"
+      @click:row="onRowClick"
+      @update:items-per-page="s => emit('update:items-per-page', s)"
+      @update:page="p => emit('update:page', p)"
+    >
+      <template #headers>
+        <tr>
+          <th class="text-left">{{ $t('user.table.username') }}</th>
+          <th class="text-left">{{ $t('user.table.displayName') }}</th>
+          <th class="text-left">{{ $t('user.table.email') }}</th>
+          <th class="text-left">{{ $t('user.table.roles') }}</th>
+          <th class="text-left">{{ $t('user.table.active') }}</th>
+          <th class="text-left" style="width: 120px">{{ $t('user.table.actions') }}</th>
+        </tr>
+      </template>
+      <template #item="{ item }">
+        <tr>
+          <td>{{ item.username }}</td>
+          <td>{{ item.displayName }}</td>
+          <td>{{ item.email }}</td>
+          <td>{{ item.roles?.join(', ') }}</td>
+          <td>{{ item.active ? '✔' : '' }}</td>
+          <td class="text-right" style="width: 120px">
+            <v-btn icon="mdi-pencil" variant="text" @click.stop="emit('detail', item)" />
+            <v-btn icon="mdi-delete" variant="text" @click.stop="emit('delete', item)" />
+          </td>
+        </tr>
+      </template>
+    </v-data-table>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import type { User } from '@/api'
+
+  interface Props {
+    items: User[]
+    loading: boolean
+    page: number
+    itemsPerPage: number
+    totalItems: number
+  }
+
+  defineProps<Props>()
+  const emit = defineEmits<{
+    (e: 'update:page' | 'update:items-per-page', value: number): void
+    (e: 'detail' | 'delete', item: User): void
+    (e: 'create'): void
+  }>()
+
+  function onRowClick (_: unknown, row: { item: User }) {
+    emit('detail', row.item)
+  }
+</script>

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -67,5 +67,29 @@
   "error": {
     "invalidUrl": "Invalid URL",
     "deleteFailed": "Failed to delete"
+  },
+  "user": {
+    "listTitle": "User Management",
+    "table": {
+      "add": "Add User",
+      "username": "Username",
+      "displayName": "Display Name",
+      "email": "Email",
+      "roles": "Roles",
+      "active": "Active",
+      "actions": "Actions"
+    },
+    "detail": {
+      "titleNew": "Add User",
+      "titleEdit": "Edit User",
+      "username": "Username",
+      "displayName": "Display Name",
+      "email": "Email",
+      "password": "Password",
+      "roles": "Roles",
+      "active": "Active",
+      "save": "Save",
+      "cancel": "Cancel"
+    }
   }
 }

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -143,5 +143,29 @@
     "password": "パスワード",
     "submit": "ログイン",
     "failed": "ログインに失敗しました"
+  },
+  "user": {
+    "listTitle": "ユーザ管理",
+    "table": {
+      "add": "ユーザ追加",
+      "username": "ユーザ名",
+      "displayName": "表示名",
+      "email": "メールアドレス",
+      "roles": "ロール",
+      "active": "有効",
+      "actions": "操作"
+    },
+    "detail": {
+      "titleNew": "ユーザ作成",
+      "titleEdit": "ユーザ編集",
+      "username": "ユーザ名",
+      "displayName": "表示名",
+      "email": "メールアドレス",
+      "password": "パスワード",
+      "roles": "ロール",
+      "active": "有効",
+      "save": "保存",
+      "cancel": "キャンセル"
+    }
   }
 }

--- a/frontend/src/pages/UserListPage.vue
+++ b/frontend/src/pages/UserListPage.vue
@@ -1,0 +1,71 @@
+<template>
+  <v-container fluid>
+    <UserTable
+      :items="items"
+      :items-per-page="size"
+      :loading="loading"
+      :page="page"
+      :total-items="total"
+      @create="onCreate"
+      @delete="onDelete"
+      @detail="onDetail"
+      @update:items-per-page="onItemsPerPageChange"
+      @update:page="onPageChange"
+    />
+    <UserDetailDialog
+      v-model:open="detailOpen"
+      :user-id="selectedId"
+      @saved="onSaved"
+    />
+  </v-container>
+</template>
+
+<script setup lang="ts">
+  import type { User } from '@/api'
+  import { storeToRefs } from 'pinia'
+  import { onMounted, ref } from 'vue'
+  import { useI18n } from 'vue-i18n'
+  import UserDetailDialog from '@/components/user/UserDetailDialog.vue'
+  import UserTable from '@/components/user/UserTable.vue'
+  import { useUserStore } from '@/stores/useUserStore'
+
+  const store = useUserStore()
+  const { items, page, size, total, loading } = storeToRefs(store)
+  const { fetchList } = store
+  const { t } = useI18n()
+
+  const detailOpen = ref(false)
+  const selectedId = ref<string>()
+
+  onMounted(() => {
+    fetchList()
+  })
+
+  function onPageChange (p: number) {
+    store.page = p
+    fetchList()
+  }
+  function onItemsPerPageChange (s: number) {
+    store.page = 1
+    store.size = s
+    fetchList()
+  }
+  function onDetail (item: User) {
+    openDetail(item.id)
+  }
+  function onCreate () {
+    openDetail()
+  }
+  function openDetail (id?: string) {
+    selectedId.value = id
+    detailOpen.value = true
+  }
+  async function onSaved () {
+    await fetchList()
+  }
+  async function onDelete (item: User) {
+    if (!confirm(t('common.confirmDelete'))) return
+    await store.delete(item.id)
+    await fetchList()
+  }
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -5,9 +5,10 @@ import NotFoundPage from '@/pages/NotFoundPage.vue'
 import OssListPage from '@/pages/OssListPage.vue'
 import ProjectListPage from '@/pages/ProjectListPage.vue'
 import SettingsPage from '@/pages/SettingsPage.vue'
+import UserListPage from '@/pages/UserListPage.vue'
 
-import { RouteName } from '@/types/routes'
 import { useAuthStore } from '@/stores/auth/useAuthStore'
+import { RouteName } from '@/types/routes'
 
 const routes: RouteRecordRaw[] = [
   {
@@ -27,6 +28,12 @@ const routes: RouteRecordRaw[] = [
     name: RouteName.ProjectList,
     component: ProjectListPage,
     meta: { titleKey: 'project.listTitle' },
+  },
+  {
+    path: '/users',
+    name: RouteName.UserList,
+    component: UserListPage,
+    meta: { titleKey: 'user.listTitle', requiresAdmin: true },
   },
   {
     path: '/settings',
@@ -49,13 +56,19 @@ const router = createRouter({
   },
 })
 
-router.beforeEach((to) => {
+router.beforeEach(async to => {
   const auth = useAuthStore()
   const name = to.name as string | undefined
   if (name !== RouteName.Login && !auth.token) {
     return { name: RouteName.Login as any }
   }
   if (name === RouteName.Login && auth.token) {
+    return { name: RouteName.OssList as any }
+  }
+  if (auth.token && auth.roles.length === 0) {
+    await auth.fetchCurrentUser().catch(() => {})
+  }
+  if (to.meta.requiresAdmin && !auth.roles.includes('ADMIN')) {
     return { name: RouteName.OssList as any }
   }
 })

--- a/frontend/src/stores/useUserStore.ts
+++ b/frontend/src/stores/useUserStore.ts
@@ -1,0 +1,51 @@
+import type { Role, User, UserCreateRequest, UserUpdateRequest } from '@/api'
+import { defineStore } from 'pinia'
+import { UsersService } from '@/api'
+
+export const useUserStore = defineStore('user', {
+  state: () => ({
+    items: [] as User[],
+    total: 0,
+    page: 1,
+    size: 50,
+    filters: { username: '', role: undefined as Role | undefined },
+    loading: false,
+  }),
+  actions: {
+    async fetchList () {
+      this.loading = true
+      try {
+        const res = await UsersService.listUsers({
+          page: this.page,
+          size: this.size,
+          username: this.filters.username || undefined,
+          role: this.filters.role,
+        })
+        this.items = res.items ?? []
+        this.total = res.total ?? 0
+      } catch (error) {
+        console.error(error)
+      } finally {
+        this.loading = false
+      }
+    },
+    async get (id: string) {
+      return await UsersService.getUser({ userId: id })
+    },
+    async create (payload: UserCreateRequest) {
+      return await UsersService.createUser({ requestBody: payload })
+    },
+    async update (id: string, payload: UserUpdateRequest) {
+      const updated = await UsersService.updateUser({ userId: id, requestBody: payload })
+      const idx = this.items.findIndex(i => i.id === updated.id)
+      if (idx !== -1) {
+        this.items[idx] = updated
+      }
+      return updated
+    },
+    async delete (id: string) {
+      await UsersService.deleteUser({ userId: id })
+      this.items = this.items.filter(i => i.id !== id)
+    },
+  },
+})

--- a/frontend/src/types/routes.ts
+++ b/frontend/src/types/routes.ts
@@ -2,6 +2,7 @@ export enum RouteName {
   Login = 'login',
   OssList = 'oss-list',
   ProjectList = 'project-list',
+  UserList = 'user-list',
   Settings = 'settings',
   NotFound = 'not-found',
 }


### PR DESCRIPTION
## Summary
- add user management page and store
- restrict user management to ADMIN and load current user roles
- show user management link only for admins

## Testing
- `npm run lint`
- `npm run type-check`
- `go generate ./...`
- `go vet ./...`
- `go test ./...`

Closes #19

------
https://chatgpt.com/codex/tasks/task_e_6896a2e8ed70832087662c08dac72591