### PR TITLE
fix(frontend): optimize OSS table column widths

### DIFF
--- a/frontend/src/components/oss/OssTable.vue
+++ b/frontend/src/components/oss/OssTable.vue
@@ -18,18 +18,18 @@
       <template #headers>
         <tr>
           <th class="text-left">{{ $t('oss.table.name') }}</th>
-          <th class="text-left">{{ $t('oss.table.homepage') }}</th>
-          <th class="text-left">{{ $t('oss.table.repository') }}</th>
+          <th class="text-left" style="width: 25%">{{ $t('oss.table.homepage') }}</th>
+          <th class="text-left" style="width: 25%">{{ $t('oss.table.repository') }}</th>
           <th class="text-left" style="width: 10ch">{{ $t('oss.table.primaryLanguage') }}</th>
           <th class="text-left" style="width: 12ch">{{ $t('oss.table.layers') }}</th>
-          <th class="text-left">{{ $t('oss.table.tags') }}</th>
+          <th class="text-left" style="width: 20%">{{ $t('oss.table.tags') }}</th>
           <th class="text-left" style="width: 120px">{{ $t('oss.table.actions') }}</th>
         </tr>
       </template>
       <template #item="{ item }">
         <tr>
           <td>{{ item.name }}</td>
-          <td>
+          <td style="width: 25%">
             <a
               v-if="item.homepageUrl"
               :href="item.homepageUrl"
@@ -37,7 +37,7 @@
               target="_blank"
             >{{ item.homepageUrl }}</a>
           </td>
-          <td>
+          <td style="width: 25%">
             <a
               v-if="item.repositoryUrl"
               :href="item.repositoryUrl"
@@ -47,7 +47,7 @@
           </td>
           <td style="width: 10ch">{{ item.primaryLanguage }}</td>
           <td style="width: 12ch">{{ (item.layers || []).join(', ') }}</td>
-          <td>
+          <td style="width: 20%">
             <v-chip
               v-for="tag in item.tags"
               :key="tag.id"


### PR DESCRIPTION
## Summary
- allocate fixed widths to OSS list table columns so the name column can expand

## Testing
- `npm run lint`
- `go generate ./...`
- `go vet ./...`
- `go test ./...`

Closes #21

------
https://chatgpt.com/codex/tasks/task_e_6896a34a0ea88320928402df9f5b44f3